### PR TITLE
install package from posit public package manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG reest_version
 WORKDIR /home/rstudio
 COPY texmf /opt/texmf-local
 RUN texhash
-RUN Rscript -e "install.packages('dotenv')"
+RUN Rscript -e "install.packages('dotenv', repos = 'https://packagemanager.posit.co/cran/2020-04-24/')"
 RUN --mount=type=secret,id=secret Rscript -e \
     "dotenv::load_dot_env('/run/secrets/secret'); remotes::install_bitbucket('dcgf/relatorios@$relatorios_version', auth_user = Sys.getenv('BITBUCKET_AUTH_USER'), password = Sys.getenv('BITBUCKET_APP_PASSWORD'))"
 RUN --mount=type=secret,id=secret Rscript -e \


### PR DESCRIPTION
Closes #6 

## Links

> On July 1 2023, the [MRAN website](https://mran.microsoft.com/) and the CRAN snapshot archive hosted therein will be retired, [Microsoft announced last week](https://techcommunity.microsoft.com/t5/azure-sql-blog/microsoft-r-application-network-retirement/ba-p/3707161).
> 
> [...]
> 
> The blog post linked below recommends using the miniCRAN package to download and save the package archives, a process [documented in detail on Microsoft Learn](https://learn.microsoft.com/en-us/sql/machine-learning/package-management/create-a-local-package-repository-using-minicran?view=sql-server-ver16). Commercial users of RStudio may also wish to explore the [Posit Package Manager](https://posit.co/products/enterprise/package-manager/) product from the creators of RStudio.
> 
> -- [MRAN Time Machine will be retired on July 1 (Revolutions)](https://blog.revolutionanalytics.com/2023/01/mran-time-machine-retired.html)

> I don't think we will undertake backporting to the 3.x images. The pre-built versions of those images should already have the dependencies they shipped with installed, though users will not easily be able to add additional packages. Users have alternatives to manually construct old environments (e.g. I believe specific archived versions of packages can be installed directly from CRAN's archive, e.g. with remotes::install_version).
>
> -- [MRAN is getting shutdown · Issue #593 · rocker-org/rocker-versioned2](https://github.com/rocker-org/rocker-versioned2/issues/593#issuecomment-1381100724)

> Following the [announcement of the retirement](https://techcommunity.microsoft.com/t5/azure-sql-blog/microsoft-r-application-network-retirement/ba-p/3707161) of the Microsoft R Application Network (MRAN) at the end of June 2023, Posit has been working with Microsoft to preserve access to historic CRAN package snapshots. R users have relied on MRAN to make their projects easier to reproduce. Posit Package Manager supports many of the same workflows.
>
> -- [Migrating from MRAN to Posit Package Manager - Posit](https://posit.co/blog/migrating-from-mran-to-posit-package-manager/)

